### PR TITLE
Add training pipeline and prediction service

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,33 @@ If you use the DeepArmocromia dataset in your work, please cite it as:
 ```
 Stacchio, L., Paolanti, M., Spigarelli, F., & Frontoni, E. (2025). Deep Armocromia: A novel dataset for face seasonal color analysis and classification. In A. Del Bue, C. Canton, J. Pont-Tuset, & T. Tommasi (Eds.), Computer Vision – ECCV 2024 Workshops (pp. 352–367). Springer Nature Switzerland. https://doi.org/10.1007/978-3-031-91569-7_22
 ```
+
+# Quick Start Guide
+
+This repository now includes example code to train a model and run a simple
+prediction service. After downloading and extracting the dataset (see
+[Dataset Download](#dataset-download)), install the required Python packages:
+
+```bash
+pip install torch torchvision pandas pillow fastapi uvicorn
+```
+
+## Training
+Use `armocromia.train` to train a ResNet-18 model:
+
+```bash
+python -m armocromia.train --csv annotations.csv --root <dataset_root>
+```
+
+The script saves model weights under `models/armocromia_resnet18.pt`.
+
+## Running the service
+After training, launch the FastAPI service:
+
+```bash
+uvicorn armocromia.service:app --host 0.0.0.0 --port 8000
+```
+
+Send POST requests with an image file to `/predict` to obtain the predicted
+seasonal label.
+

--- a/armocromia/dataset.py
+++ b/armocromia/dataset.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from typing import Optional, Callable
+
+import pandas as pd
+from PIL import Image
+from torch.utils.data import Dataset
+
+
+class ArmocromiaDataset(Dataset):
+    """Dataset for Deep Armocromia images.
+
+    Expects an annotations CSV with columns including `partition`, `class`, and
+    image file paths (e.g. `path_rgb_original`). The CSV structure follows the
+    README description.
+    """
+
+    def __init__(self, csv_path: str | Path, root_dir: str | Path,
+                 partition: str = "train",
+                 transform: Optional[Callable] = None) -> None:
+        csv_path = Path(csv_path)
+        root_dir = Path(root_dir)
+        if not csv_path.exists():
+            raise FileNotFoundError(csv_path)
+        self.data = pd.read_csv(csv_path)
+        self.data = self.data[self.data["partition"] == partition]
+        self.root = root_dir
+        self.transform = transform
+
+        # Map string labels to integer ids
+        self.label_map = {label: i for i, label in
+                          enumerate(sorted(self.data["class"].unique()))}
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __getitem__(self, idx: int):
+        row = self.data.iloc[idx]
+        img_path = self.root / row["path_rgb_original"]
+        image = Image.open(img_path).convert("RGB")
+        label = self.label_map[row["class"]]
+        if self.transform:
+            image = self.transform(image)
+        return image, label

--- a/armocromia/service.py
+++ b/armocromia/service.py
@@ -1,0 +1,66 @@
+"""Simple FastAPI service for classifying new images using a trained model."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from fastapi import FastAPI, UploadFile, File
+from PIL import Image
+import torch
+from torchvision import models, transforms
+
+from .dataset import ArmocromiaDataset
+
+
+app = FastAPI(title="Deep Armocromia Service")
+
+# global variables set in `load_model`
+model = None
+label_map = None
+transform = transforms.Compose(
+    [
+        transforms.Resize((224, 224)),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+    ]
+)
+
+
+def load_model(weights_path: str | Path, csv_path: str | Path) -> None:
+    """Load trained model and label map from disk."""
+    global model, label_map
+    csv_path = Path(csv_path)
+    ds = ArmocromiaDataset(csv_path, csv_path.parent, partition="train")
+    label_map = ds.label_map
+
+    model = models.resnet18()
+    model.fc = torch.nn.Linear(model.fc.in_features, len(label_map))
+    state = torch.load(weights_path, map_location="cpu")
+    model.load_state_dict(state)
+    model.eval()
+
+
+@app.on_event("startup")
+def startup_event():
+    weights = Path("models/armocromia_resnet18.pt")
+    csv = Path("annotations.csv")
+    if weights.exists() and csv.exists():
+        load_model(weights, csv)
+    else:
+        print("Model weights or annotations not found. Service will not predict.")
+
+
+@app.post("/predict")
+async def predict(file: UploadFile = File(...)) -> dict[str, str]:
+    if model is None or label_map is None:
+        return {"error": "model not loaded"}
+    image_bytes = await file.read()
+    img = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    img = transform(img).unsqueeze(0)
+    with torch.no_grad():
+        logits = model(img)
+        pred_idx = logits.argmax(dim=1).item()
+    label = [k for k, v in label_map.items() if v == pred_idx][0]
+    return {"label": label}
+

--- a/armocromia/train.py
+++ b/armocromia/train.py
@@ -1,0 +1,95 @@
+"""Example training script for the Deep Armocromia dataset.
+
+Usage:
+    python -m armocromia.train --csv annotations.csv --root data/ \
+                               --epochs 10 --batch-size 32
+
+This script assumes you have already downloaded and extracted the dataset as
+explained in the README. It trains a simple ResNet model on the dataset.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+from torchvision import models, transforms
+
+from .dataset import ArmocromiaDataset
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train a model on Deep Armocromia")
+    parser.add_argument("--csv", type=Path, required=True, help="Path to annotations.csv")
+    parser.add_argument("--root", type=Path, required=True, help="Dataset root directory")
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--num-workers", type=int, default=4)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    transform = transforms.Compose(
+        [
+            transforms.Resize((224, 224)),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
+
+    train_ds = ArmocromiaDataset(args.csv, args.root, partition="train", transform=transform)
+    val_ds = ArmocromiaDataset(args.csv, args.root, partition="val", transform=transform)
+
+    train_loader = DataLoader(
+        train_ds, batch_size=args.batch_size, shuffle=True, num_workers=args.num_workers
+    )
+    val_loader = DataLoader(
+        val_ds, batch_size=args.batch_size, shuffle=False, num_workers=args.num_workers
+    )
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = models.resnet18(weights="DEFAULT")
+    model.fc = nn.Linear(model.fc.in_features, len(train_ds.label_map))
+    model.to(device)
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+
+    for epoch in range(args.epochs):
+        model.train()
+        for images, labels in train_loader:
+            images, labels = images.to(device), labels.to(device)
+            optimizer.zero_grad()
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+        # simple validation loop
+        model.eval()
+        correct = 0
+        total = 0
+        with torch.no_grad():
+            for images, labels in val_loader:
+                images, labels = images.to(device), labels.to(device)
+                outputs = model(images)
+                preds = outputs.argmax(dim=1)
+                correct += (preds == labels).sum().item()
+                total += labels.size(0)
+        acc = 100.0 * correct / total if total else 0.0
+        print(f"Epoch {epoch+1}/{args.epochs} - val accuracy: {acc:.2f}%")
+
+    Path("models").mkdir(exist_ok=True)
+    model_path = Path("models/armocromia_resnet18.pt")
+    torch.save(model.state_dict(), model_path)
+    print(f"Model saved to {model_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `armocromia` package with dataset loader, training script and FastAPI service
- extend README with quick start instructions

## Testing
- `python -m py_compile armocromia/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685339a7a770832b887be078e528e014